### PR TITLE
Output Log Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.phar
 /vendor/
+.idea

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -53,6 +53,7 @@ class Resque_Job
 	 * @param boolean $monitor Set to true to be able to monitor the status of a job.
 	 *
 	 * @return string
+     * @throws InvalidArgumentException
 	 */
 	public static function create($queue, $class, $args = null, $monitor = false)
 	{
@@ -149,6 +150,7 @@ class Resque_Job
 	 * Get the instantiated object for this job that will be performing work.
 	 *
 	 * @return object Instance of the object that this job belongs to.
+     * @throws Resque_Exception
 	 */
 	public function getInstance()
 	{
@@ -265,5 +267,13 @@ class Resque_Job
 					'args' => !empty($this->payload['args']) ? $this->payload['args'] : ''
 				));
 	}
+
+    /**
+     * @return string
+     */
+    public function getOutput()
+    {
+        return ob_get_contents();
+    }
 }
 

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -276,9 +276,24 @@ class Resque_Worker
         try {
             Resque_Event::trigger('afterFork', $job);
             $job->perform();
-            $this->log(array('message' => 'done ID:' . $job->payload['id'], 'data' => array('type' => 'done', 'job_id' => $job->payload['id'], 'time' => round(microtime(true) - $startTime, 3) * 1000)), self::LOG_TYPE_INFO);
+            $this->log([
+                'message' => 'done ID:' . $job->payload['id'],
+                'data' => [
+                    'type' => 'done',
+                    'job_id' => $job->payload['id'],
+                    'output' => $job->getOutput(),
+                    'time' => round(microtime(true) - $startTime, 3) * 1000]
+            ], self::LOG_TYPE_INFO);
         } catch (Exception $e) {
-            $this->log(array('message' => $job . ' failed: ' . $e->getMessage(), 'data' => array('type' => 'fail', 'log' => $e->getMessage(), 'job_id' => $job->payload['id'], 'time' => round(microtime(true) - $startTime, 3) * 1000)), self::LOG_TYPE_ERROR);
+            $this->log([
+                'message' => $job . ' failed: ' . $e->getMessage(),
+                'data' => [
+                    'type' => 'fail',
+                    'log' => $e->getMessage(),
+                    'output' => $job->getOutput(),
+                    'job_id' => $job->payload['id'],
+                    'time' => round(microtime(true) - $startTime, 3) * 1000]
+            ], self::LOG_TYPE_ERROR);
             $job->fail($e);
             return;
         }
@@ -337,6 +352,7 @@ class Resque_Worker
      * Return values are those of pcntl_fork().
      *
      * @return int -1 if the fork failed, 0 for the forked child, the PID of the child for the parent.
+     * @throws RuntimeException
      */
     protected function fork()
     {


### PR DESCRIPTION
Adding provisions to allow jobs to have output logs and capture them.
This allows us to see the status on a success since out of the box
this library only show success when things work and not much more
